### PR TITLE
root-height update fix && delete last element bug fix

### DIFF
--- a/client/src/components/KonvaStageV2.jsx
+++ b/client/src/components/KonvaStageV2.jsx
@@ -3,13 +3,19 @@ import { Stage, Layer, Rect, Image, Transformer } from 'react-konva';
 import useImage from 'use-image';
 import { useDispatch, useSelector } from 'react-redux';
 import { updateComponentRectanglePosition } from '../utils/reducers/designSliceV2';
+import { setSelectedIdx } from '../utils/reducers/appSlice';
 
-export default function KonvaStage({ userImage, selectedIdx, setSelectedIdx }) {
+export default function KonvaStage({ userImage }) {
   const [image] = useImage(userImage);
 
   // redux state
   const components = useSelector((state) => state.designV2.components);
-  const rectangles = components.map((item) => item.rectangle);
+  const selectedIdx = useSelector((state) => state.app.selectedIdx);
+  console.log('components are', components);
+  const rectangles = components.map((item) => {
+    console.log(item);
+    return item.rectangle;
+  });
   const dispatch = useDispatch();
 
   // refs and other state
@@ -37,7 +43,7 @@ export default function KonvaStage({ userImage, selectedIdx, setSelectedIdx }) {
     // prevent stage from deselecting the shape
     e.cancelBubble = true;
     const clickedIdx = components.findIndex((item) => item._id === componentId);
-    setSelectedIdx(clickedIdx);
+    dispatch(setSelectedIdx(clickedIdx));
   }
 
   // handle drag and transform

--- a/client/src/components/PastDesigns/DesignCard.jsx
+++ b/client/src/components/PastDesigns/DesignCard.jsx
@@ -17,7 +17,6 @@ export default function DesignCard({ design, setLocalSelectedDesignId }) {
   const dispatch = useDispatch();
   const created_at = new Date(design.created_at).toLocaleDateString();
   const last_updated = new Date(design.last_updated).toLocaleDateString();
-  console.log('design is', design);
 
   const handleViewDesign = async () => {
     try {

--- a/client/src/components/Workspace/Workspace.jsx
+++ b/client/src/components/Workspace/Workspace.jsx
@@ -2,7 +2,7 @@ import React, { useState, useEffect } from 'react';
 import Box from '@mui/material/Box';
 import Paper from '@mui/material/Paper';
 
-import { useSelector } from 'react-redux';
+import { useDispatch, useSelector } from 'react-redux';
 import WorkspaceLeft from './WorkspaceLeft';
 import WorkspaceRight from './WorkspaceRight';
 import KonvaStage from '../KonvaStageV2';
@@ -11,23 +11,28 @@ import UserImageUpload from '../functionalButtons/UserImageUploadButton';
 import DesignTitleInput from '../userInputs/DesignTitleInput';
 import ViewKeyboardShortcut from '../functionalButtons/ViewKeyboardShortcut';
 import WorkspaceToolbar from './WorkspaceToolbar';
+import { setSelectedIdx } from '../../utils/reducers/appSlice';
 
 export default function Workspace() {
-  const [selectedIdx, setSelectedIdx] = useState(null);
-  const { image_url, _id, components } = useSelector((state) => state.designV2);
-  if (selectedIdx === components.length) setSelectedIdx(null);
+  const { image_url, components } = useSelector((state) => state.designV2);
+  const selectedIdx = useSelector((state) => state.app.selectedIdx);
+  const dispatch = useDispatch();
+
+  if (selectedIdx === components.length) dispatch(setSelectedIdx(null));
 
   const handleKeyPress = (e) => {
     if (e.altKey && e.keyCode === 87) {
-      if (selectedIdx === null) setSelectedIdx(0);
+      if (selectedIdx === null) dispatch(setSelectedIdx(0));
       else {
-        setSelectedIdx(Math.max(selectedIdx - 1, 0));
+        dispatch(setSelectedIdx(Math.max(selectedIdx - 1, 0)));
       }
     }
     if (e.altKey && e.keyCode === 83) {
-      if (selectedIdx === null) setSelectedIdx(components.length - 1);
+      if (selectedIdx === null) dispatch(setSelectedIdx(components.length - 1));
       else {
-        setSelectedIdx(Math.min(selectedIdx + 1, components.length - 1));
+        dispatch(
+          setSelectedIdx(Math.min(selectedIdx + 1, components.length - 1))
+        );
       }
     }
   };
@@ -44,7 +49,8 @@ export default function Workspace() {
       <Box
         sx={{
           display: 'flex',
-        }}>
+        }}
+      >
         <DesignTitleInput />
       </Box>
 
@@ -56,8 +62,9 @@ export default function Workspace() {
           alignItems: 'center',
           marginBottom: '10px',
           gap: '10px',
-        }}>
-        {selectedIdx !== null && (
+        }}
+      >
+        {selectedIdx !== null && components[selectedIdx] && (
           <WorkspaceToolbar
             rectangle={components[selectedIdx].rectangle}
             key={selectedIdx}
@@ -66,21 +73,11 @@ export default function Workspace() {
       </Box>
 
       <Box gridColumn='span 2'>
-        <WorkspaceLeft
-          selectedIdx={selectedIdx}
-          setSelectedIdx={setSelectedIdx}
-        />
+        <WorkspaceLeft />
       </Box>
 
       <Box gridColumn='span 8' align-items='center'>
-        {/* <img src={image_url} style={{ maxWidth: '100%' }} />
-        {image_url && (
-          <KonvaStage
-            userImage={image_url}
-            selectedIdx={selectedIdx}
-            setSelectedIdx={setSelectedIdx}
-          />
-        )} */}
+        {image_url && <KonvaStage userImage={image_url} />}
       </Box>
       <Box
         gridColumn='span 2'
@@ -88,8 +85,9 @@ export default function Workspace() {
           display: 'flex',
 
           justifyContent: 'center',
-        }}>
-        <WorkspaceRight selectedIdx={selectedIdx} />
+        }}
+      >
+        <WorkspaceRight />
       </Box>
     </Box>
   );

--- a/client/src/components/Workspace/WorkspaceLeft.jsx
+++ b/client/src/components/Workspace/WorkspaceLeft.jsx
@@ -1,7 +1,7 @@
 import React, { useState, Fragment } from 'react';
 import Box from '@mui/material/Box';
 import IconButton from '@mui/material/IconButton';
-import { useSelector } from 'react-redux';
+import { useDispatch, useSelector } from 'react-redux';
 import List from '@mui/material/List';
 import ListItemButton from '@mui/material/ListItemButton';
 import ListItemText from '@mui/material/ListItemText';
@@ -14,16 +14,20 @@ import DeleteComponentButton from '../functionalButtons/DeleteComponentButton';
 import { ThemeProvider, useTheme } from '@mui/material';
 import { WorkspaceLeftLightTheme } from '../../styles/WorkspaceLeftTheme';
 
-export default function WorkspaceLeft({ selectedIdx, setSelectedIdx }) {
+import { setSelectedIdx } from '../../utils/reducers/appSlice';
+
+export default function WorkspaceLeft() {
   const components = useSelector((state) => state.designV2.components);
   const theme = useTheme();
   const WorkspaceLeftTheme =
     theme.palette.mode === 'dark' ? theme : WorkspaceLeftLightTheme;
 
+  const dispatch = useDispatch();
+
   return (
     <ThemeProvider theme={WorkspaceLeftTheme}>
       <Box sx={{ display: 'flex', flexDirection: 'column' }}>
-        <AddNewComponent size='sm' setSelectedIdx={setSelectedIdx} />
+        <AddNewComponent size='sm' />
         <List width='75%'>
           {components.map((item, idx) => (
             <ComponentDisplay
@@ -33,9 +37,8 @@ export default function WorkspaceLeft({ selectedIdx, setSelectedIdx }) {
               idx={idx}
               handleListItemClick={(e) => {
                 e.stopPropagation();
-                setSelectedIdx(idx);
+                dispatch(setSelectedIdx(idx));
               }}
-              selectedIdx={selectedIdx}
               isLeaf={
                 idx > 0 &&
                 components.filter((e) => e.parent_id === item._id).length === 0
@@ -48,22 +51,15 @@ export default function WorkspaceLeft({ selectedIdx, setSelectedIdx }) {
   );
 }
 
-function ComponentDisplay({
-  component,
-  idx,
-  handleListItemClick,
-  selectedIdx,
-  isLeaf,
-}) {
+function ComponentDisplay({ component, idx, handleListItemClick, isLeaf }) {
   const [openEditor, setOpenEditor] = useState(false);
+  const selectedIdx = useSelector((state) => state.app.selectedIdx);
   const selected = selectedIdx === idx;
 
   return (
     <ListItemButton
       value='NewComponentInputBox'
       selected={selected}
-      // onClick={() => handleListItemClick(idx)}
-      // i added this
       onClick={handleListItemClick}
       sx={{
         display: 'flex',
@@ -71,12 +67,14 @@ function ComponentDisplay({
         justifyContent: 'center',
         padding: '10px',
         width: '75%',
-      }}>
+      }}
+    >
       <Box
         sx={{
           display: 'flex',
           width: '75%',
-        }}>
+        }}
+      >
         <ListItemText primary={component.name} />
         {selected && (
           <IconButton
@@ -84,7 +82,8 @@ function ComponentDisplay({
             onClick={(e) => {
               e.stopPropagation();
               setOpenEditor(true);
-            }}>
+            }}
+          >
             <EditIcon />
           </IconButton>
         )}

--- a/client/src/components/Workspace/WorkspaceRight.jsx
+++ b/client/src/components/Workspace/WorkspaceRight.jsx
@@ -10,8 +10,9 @@ import ViewKeyboardShortcut from '../functionalButtons/ViewKeyboardShortcut';
 import DeleteDesignButton from '../functionalButtons/DeleteDesignButton';
 import UserImageUpload from '../functionalButtons/UserImageUploadButton';
 
-export default function WorkspaceRight({ selectedIdx }) {
+export default function WorkspaceRight() {
   const components = useSelector((state) => state.designV2.components);
+  const { selectedIdx } = useSelector((state) => state.app);
   const { _id } = useSelector((state) => state.designV2);
   const tree = convertToTree(components);
   const code = jsxCode(components, tree);
@@ -24,7 +25,8 @@ export default function WorkspaceRight({ selectedIdx }) {
           display: 'flex',
           flexDirection: 'column',
           justifyContent: 'space-between',
-        }}>
+        }}
+      >
         <ViewKeyboardShortcut
           sx={{ position: 'absolute', justifySelf: 'end' }}
         />

--- a/client/src/components/functionalButtons/AddNewComponentButton.jsx
+++ b/client/src/components/functionalButtons/AddNewComponentButton.jsx
@@ -45,6 +45,7 @@ export default function AddNewComponentButton() {
             })
           );
           dispatch(setMessage(successMess));
+          setName('');
         } else {
           const errMessage = name.length === 0 ? emptyNameErr : firstCharErr;
           dispatch(setMessage(errMessage));

--- a/client/src/components/functionalButtons/DeleteComponentButton.jsx
+++ b/client/src/components/functionalButtons/DeleteComponentButton.jsx
@@ -5,7 +5,7 @@ import DeleteIcon from '@mui/icons-material/Delete';
 import IconButton from '@mui/material/IconButton';
 import Tooltip from '@mui/material/Tooltip';
 
-import { setMessage } from '../../utils/reducers/appSlice';
+import { setMessage, setSelectedIdx } from '../../utils/reducers/appSlice';
 import { deleteComponent } from '../../utils/reducers/designSliceV2';
 
 export default function DeleteComponentButton({
@@ -32,6 +32,7 @@ export default function DeleteComponentButton({
             dispatch(deleteComponent(componentId));
           }
           dispatch(setMessage(message));
+          dispatch(setSelectedIdx(null));
         }}
       >
         <DeleteIcon />

--- a/client/src/components/functionalButtons/UserImageUploadButton.jsx
+++ b/client/src/components/functionalButtons/UserImageUploadButton.jsx
@@ -1,16 +1,20 @@
 import React, { Fragment } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
-import Fab from '@mui/material/Fab';
+import Button from '@mui/material/Button';
 import { setMessage } from '../../utils/reducers/appSlice';
 import CloudUploadIcon from '@mui/icons-material/CloudUpload';
 import Tooltip from '@mui/material/Tooltip';
 import { styled } from '@mui/material/styles';
-import { newDesign, updateDesign } from '../../utils/reducers/designSliceV2';
+import {
+  newDesign,
+  updateDesign,
+  updateRootHeight,
+} from '../../utils/reducers/designSliceV2';
 
 export default function UserImageUploadButton() {
   const dispatch = useDispatch();
   const designId = useSelector((state) => state.designV2._id);
-  const image_url = useSelector((state) => state.designV2.image_url);
+  const { image_url, components } = useSelector((state) => state.designV2);
   const tooltip = designId ? 'upload a new image' : 'replace image';
 
   function handleFileChange(e) {
@@ -26,16 +30,10 @@ export default function UserImageUploadButton() {
         const img = new Image();
 
         img.onload = () => {
-          console.log('width, height are', img.width, img.height);
-
           const setWidth = 800;
           const imageHeight = img.height * (setWidth / img.width);
-          console.log(imageHeight);
-
           if (!designId) {
-            dispatch(
-              newDesign({ userImage, imageWidth: setWidth, imageHeight })
-            );
+            dispatch(newDesign({ userImage, imageHeight }));
           } else {
             const url = new URL(image_url);
             dispatch(
@@ -44,11 +42,12 @@ export default function UserImageUploadButton() {
                 body: {
                   userImage,
                   imageToDelete: url.pathname.slice(1),
-                  imageWidth: setWidth,
                   imageHeight,
+                  rootId: components[0]._id,
                 },
               })
             );
+            dispatch(updateRootHeight(imageHeight));
           }
         };
 
@@ -60,9 +59,12 @@ export default function UserImageUploadButton() {
 
   return (
     <Fragment>
-      <Tooltip width='36px' title={tooltip}>
-        <Fab size='small' component='label' variant='contained'>
-          <CloudUploadIcon />
+      <Tooltip title={tooltip}>
+        <Button
+          component='label'
+          variant='contained'
+          startIcon={<CloudUploadIcon />}
+        >
           {designId ? '' : 'Upload Image'}
           <VisuallyHiddenInput
             type='file'
@@ -70,7 +72,7 @@ export default function UserImageUploadButton() {
             accept='image/*'
             onChange={handleFileChange}
           />
-        </Fab>
+        </Button>
       </Tooltip>
     </Fragment>
   );

--- a/client/src/components/functionalButtons/ViewDomTreeButton.jsx
+++ b/client/src/components/functionalButtons/ViewDomTreeButton.jsx
@@ -8,6 +8,7 @@ import {
   Fab,
   List,
   FormLabel,
+  Box,
   IconButton,
 } from '@mui/material';
 import { ImTree } from 'react-icons/im';
@@ -31,12 +32,13 @@ export default function ViewDomTreeButton({ tree }) {
     };
   }, [viewTree]);
   return (
-    <Fragment
+    <Box
       sx={{
         display: 'flex',
         flexDirection: 'row',
         justifyContent: 'center',
-      }}>
+      }}
+    >
       <Tooltip title='View Dom tree'>
         <Fab size='small' variant='contained' onClick={() => setViewTree(true)}>
           <svg
@@ -45,7 +47,8 @@ export default function ViewDomTreeButton({ tree }) {
             height='16'
             fill='currentColor'
             className='bi bi-diagram-3-fill'
-            viewBox='0 0 16 16'>
+            viewBox='0 0 16 16'
+          >
             <path
               fillRule='evenodd'
               d='M6 3.5A1.5 1.5 0 0 1 7.5 2h1A1.5 1.5 0 0 1 10 3.5v1A1.5 1.5 0 0 1 8.5 6v1H14a.5.5 0 0 1 .5.5v1a.5.5 0 0 1-1 0V8h-5v.5a.5.5 0 0 1-1 0V8h-5v.5a.5.5 0 0 1-1 0v-1A.5.5 0 0 1 2 7h5.5V6A1.5 1.5 0 0 1 6 4.5zm-6 8A1.5 1.5 0 0 1 1.5 10h1A1.5 1.5 0 0 1 4 11.5v1A1.5 1.5 0 0 1 2.5 14h-1A1.5 1.5 0 0 1 0 12.5zm6 0A1.5 1.5 0 0 1 7.5 10h1a1.5 1.5 0 0 1 1.5 1.5v1A1.5 1.5 0 0 1 8.5 14h-1A1.5 1.5 0 0 1 6 12.5zm6 0a1.5 1.5 0 0 1 1.5-1.5h1a1.5 1.5 0 0 1 1.5 1.5v1a1.5 1.5 0 0 1-1.5 1.5h-1a1.5 1.5 0 0 1-1.5-1.5z'
@@ -61,7 +64,7 @@ export default function ViewDomTreeButton({ tree }) {
         tree={tree}
         setViewTree={setViewTree}
       />
-    </Fragment>
+    </Box>
   );
 }
 
@@ -91,7 +94,8 @@ const renderRectSvgNode = ({ nodeDatum, toggleNode }) => {
               height: '100%',
               y: '-50px',
               padding: `${padding}px`,
-            }}>
+            }}
+          >
             <Fab
               variant='extended'
               onClick={toggleNode}
@@ -100,11 +104,13 @@ const renderRectSvgNode = ({ nodeDatum, toggleNode }) => {
                 flexDirection: 'row',
                 width: `${paddedWidth}px`,
                 alignItems: 'center',
-              }}>
+              }}
+            >
               <FormLabel
                 sx={{
                   fontSize: '8px',
-                }}>
+                }}
+              >
                 {nodeDatum.attributes.tag}
               </FormLabel>
               <List>{nodeDatum.name}</List>
@@ -132,7 +138,8 @@ function DOMTreeBackdrop({ viewTree, tree, setViewTree }) {
         backgroundColor: '#ffffff4D',
       }}
       open={viewTree}
-      onDoubleClickCapture={() => setViewTree(false)}>
+      onDoubleClickCapture={() => setViewTree(false)}
+    >
       <Tree
         data={tree}
         rootNodeClassName='node__root'

--- a/client/src/components/functionalButtons/ViewKeyboardShortcut.jsx
+++ b/client/src/components/functionalButtons/ViewKeyboardShortcut.jsx
@@ -13,7 +13,7 @@ import ListItem from '@mui/material/ListItem';
 import ListItemIcon from '@mui/material/ListItemIcon';
 import ListItemText from '@mui/material/ListItemText';
 import Divider from '@mui/material/Divider';
-import AddIcon from '@mui/icons-material/Add';
+import Box from '@mui/material/Box';
 import Stack from '@mui/material/Stack';
 
 import {
@@ -29,25 +29,27 @@ import { Typography } from '@mui/material';
 export default function ViewKeyboardShortcut() {
   const [open, setOpen] = useState(false);
   return (
-    <Fragment
+    <Box
       sx={{
         display: 'flex',
         width: '40px',
         justifyContent: 'center',
-      }}>
+      }}
+    >
       <Tooltip title='View keyboard shortcuts'>
         <Fab
           size='small'
           component='label'
           variant='contained'
-          onClick={() => setOpen(true)}>
+          onClick={() => setOpen(true)}
+        >
           <KeyboardIcon />
         </Fab>
       </Tooltip>
       <BackdropSnackbar open={open} setOpen={setOpen} />
 
       <ShortcutBackdrop open={open} setOpen={setOpen} />
-    </Fragment>
+    </Box>
   );
 }
 
@@ -60,7 +62,8 @@ function ShortcutBackdrop({ open, setOpen }) {
         backgroundColor: '#ffffff4D',
       }}
       open={open}
-      onDoubleClick={() => setOpen(false)}>
+      onDoubleClick={() => setOpen(false)}
+    >
       <List className='keyboard-shortcuts'>
         <ListItem className='shortcut'>
           <ListItemIcon sx={{ color: 'white' }}>esc</ListItemIcon>

--- a/client/src/components/userInputs/DesignTitleInput.jsx
+++ b/client/src/components/userInputs/DesignTitleInput.jsx
@@ -15,7 +15,12 @@ export default function DesignTitleInput() {
       value={title}
       onChange={(e) => setTitle(e.target.value)}
       onBlur={() => {
-        dispatch(updateDesign({ designId: design._id, body: { title } }));
+        dispatch(
+          updateDesign({
+            designId: design._id,
+            body: { title },
+          })
+        );
       }}
     />
   );

--- a/client/src/utils/fetchRequests.ts
+++ b/client/src/utils/fetchRequests.ts
@@ -21,8 +21,9 @@ export function updateDesignRequest(
   body: {
     userImage: string;
     imageToDelete?: string;
-    imageWidth: number;
-    imageHeight: number;
+    imageHeight?: number;
+    title?: string;
+    rootId?: number;
   }
 ) {
   return fetch(`/designs/update/${designId}`, {

--- a/client/src/utils/reducers/appSlice.js
+++ b/client/src/utils/reducers/appSlice.js
@@ -3,6 +3,7 @@ import { createSlice } from '@reduxjs/toolkit';
 const initialState = {
   message: null,
   page: 'HOME',
+  selectedIdx: null,
 };
 
 const appSlice = createSlice({
@@ -18,11 +19,14 @@ const appSlice = createSlice({
     goToPage: (state, action) => {
       state.page = action.payload;
     },
-    resetApp: (state) => initialState,
+    resetApp: () => initialState,
+    setSelectedIdx: (state, action) => {
+      state.selectedIdx = action.payload;
+    },
   },
 });
 
-export const { setMessage, resetMessage, goToPage, resetApp } =
+export const { setMessage, resetMessage, goToPage, resetApp, setSelectedIdx } =
   appSlice.actions;
 
 export default appSlice.reducer;

--- a/client/src/utils/reducers/designSliceV2.js
+++ b/client/src/utils/reducers/designSliceV2.js
@@ -100,13 +100,8 @@ const designSliceV2 = createSlice({
   initialState,
   reducers: {
     resetDesign: () => initialState,
-    updateComponentBorderColor: (state, action) => {
-      const { id, borderColor } = action.payload;
-      // find component with the given _id and update its border color
-      const component = state.components.find((comp) => comp._id === id);
-      if (component) {
-        component.borderColor = borderColor;
-      }
+    updateRootHeight: (state, action) => {
+      state.components[0].rectangle.height = action.payload;
     },
     setSearchTerm: (state, action) => {
       state.searchTerm = action.payload;
@@ -192,6 +187,6 @@ const designSliceV2 = createSlice({
   },
 });
 
-export const { resetDesign, updateComponentBorderColor, setSearchTerm } =
+export const { resetDesign, setSearchTerm, updateRootHeight } =
   designSliceV2.actions;
 export default designSliceV2.reducer;

--- a/server/controllers/rectangleController.js
+++ b/server/controllers/rectangleController.js
@@ -3,14 +3,14 @@ const db = require('../models/dbModel');
 // create rectangle for RootContainer component
 const createRootRectangle = (req, res, next) => {
   const rootId = res.locals.design.components[0]._id;
-  const { imageWidth, imageHeight } = req.body;
+  const { imageHeight } = req.body;
   console.log(rootId, imageWidth, imageHeight);
   return db
     .query(
       'INSERT INTO rectangles (component_id, width, height) ' +
         'VALUES ($1, $2, $3) ' +
         'RETURNING *;',
-      [rootId, imageWidth, imageHeight]
+      [rootId, 800, imageHeight]
     )
     .then((data) => {
       res.locals.design.components[0].rectangle = data.rows[0];
@@ -22,6 +22,24 @@ const createRootRectangle = (req, res, next) => {
           'Express error handler caught rectangleController.createRootRectangle middleware error' +
           err,
         message: { err: 'createRootRectangle: ' + err },
+      })
+    );
+};
+
+const updateRootRectangle = (req, res, next) => {
+  const { rootId, imageHeight } = req.body;
+  return db
+    .query('UPDATE rectangles SET height = $1 WHERE component_id = $2;', [
+      imageHeight,
+      rootId,
+    ])
+    .then(() => next())
+    .catch((err) =>
+      next({
+        log:
+          'Express error handler caught rectangleController.createComponentRectangle middleware error' +
+          err,
+        message: { err: 'createComponentRectangle: ' + err },
       })
     );
 };
@@ -149,4 +167,5 @@ module.exports = {
   deleteComponentRectangle,
   updateComponentRectanglePosition,
   updateComponentRectangleStyle,
+  updateRootRectangle,
 };

--- a/server/routes/designsRouter.js
+++ b/server/routes/designsRouter.js
@@ -31,6 +31,7 @@ router.post(
   imageController.deleteImage,
   imageController.uploadImage,
   designController.updateDesign,
+  rectangleController.updateRootRectangle,
   sendDesign
 );
 


### PR DESCRIPTION
## Description
- moved `selecedIdx` and `setSelectedIdx` to `appSlice`, now we can access them from any component without having to prop drill
- added `rectangleController.updateRootRectangle` to `/designs/update/:designId` route, now the height should change proportionally when user changed the design image
- fix the error that pops up when delete the last component from a design


<!--
Please do not leave this blank
This PR [adds/removes/fixes/replaces] the [feature/bug/etc].
-->

## What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [x] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] ✅ Test
- [ ] ⏩ Revert

<!-- note: PRs with deleted sections will be marked invalid -->

<!--
  For Work In Progress Pull Requests, please use the Draft PR feature,
  see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

  For a timely review/response, please avoid force-pushing additional
  commits if your PR already received reviews or comments.

  Before submitting a Pull Request, please ensure you've done the following:
  - 📖 Read the Open Sauced Contributing Guide: https://github.com/open-sauced/.github/blob/main/CONTRIBUTING.md.
  - 📖 Read the Open Sauced Code of Conduct: https://github.com/open-sauced/.github/blob/main/CODE_OF_CONDUCT.md.
  - 👷‍♀️ Create small PRs. In most cases, this will be possible.
  - ✅ Provide tests for your changes.
  - 📝 Use descriptive commit messages.
  - 📗 Update any related documentation and include any relevant screenshots.
-->
