### PR TITLE
Code block popper

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@
     <img src="images/logo.png" alt="Logo" width="80" height="80">
   </a> -->
 
-<h3 align="center">Reactraft</h3>
+<h3 align="center">ReaCraft</h3>
 
   <p align="center">
 Streamlining React Development from Design to Deployment

--- a/client/src/components/SideDrawer.jsx
+++ b/client/src/components/SideDrawer.jsx
@@ -1,6 +1,4 @@
-import React, { useState } from 'react';
-import Tabs from '@mui/material/Tabs';
-import Tab from '@mui/material/Tab';
+import React from 'react';
 import AddPhotoAlternateIcon from '@mui/icons-material/AddPhotoAlternate';
 import HomeIcon from '@mui/icons-material/Home';
 import Drawer from '@mui/material/Drawer';
@@ -15,7 +13,6 @@ import Stack from '@mui/material/Stack';
 import Fab from '@mui/material/Fab';
 
 export default function SideDrawer({ drawerOpen, setDrawerOpen }) {
-  const [value, setValue] = useState(0);
   const dispatch = useDispatch();
 
   function handleClick(page) {

--- a/client/src/components/Workspace/Workspace.jsx
+++ b/client/src/components/Workspace/Workspace.jsx
@@ -1,15 +1,11 @@
-import React, { useState, useEffect } from 'react';
+import React, { useEffect } from 'react';
 import Box from '@mui/material/Box';
-import Paper from '@mui/material/Paper';
 
 import { useDispatch, useSelector } from 'react-redux';
 import WorkspaceLeft from './WorkspaceLeft';
 import WorkspaceRight from './WorkspaceRight';
 import KonvaStage from '../KonvaStageV2';
-import DeleteDesignButton from '../functionalButtons/DeleteDesignButton';
-import UserImageUpload from '../functionalButtons/UserImageUploadButton';
 import DesignTitleInput from '../userInputs/DesignTitleInput';
-import ViewKeyboardShortcut from '../functionalButtons/ViewKeyboardShortcut';
 import WorkspaceToolbar from './WorkspaceToolbar';
 import { setSelectedIdx } from '../../utils/reducers/appSlice';
 
@@ -77,16 +73,7 @@ export default function Workspace() {
       </Box>
 
       <Box gridColumn='span 8' align-items='center'>
-
-        {/* <img src={image_url} style={{ maxWidth: '100%' }} /> */}
-        {image_url && (
-          <KonvaStage
-            userImage={image_url}
-            selectedIdx={selectedIdx}
-            setSelectedIdx={setSelectedIdx}
-          />
-        )}
-      /* {image_url && <KonvaStage userImage={image_url} />} */
+        {image_url && <KonvaStage userImage={image_url} />}
       </Box>
       <Box
         gridColumn='span 2'

--- a/client/src/hooks/useOutsideClick.js
+++ b/client/src/hooks/useOutsideClick.js
@@ -1,0 +1,15 @@
+import React, { useEffect } from 'react';
+
+export default function useOutsideClick(ref, callback) {
+  useEffect(() => {
+    function handleClickOutside(event) {
+      if (ref.current && !ref.current.contains(event.target)) {
+        callback();
+      }
+    }
+    document.addEventListener('mousedown', handleClickOutside);
+    return () => {
+      document.removeEventListener('mousedown', handleClickOutside);
+    };
+  }, [ref, callback]);
+}


### PR DESCRIPTION
## Description
- Replaced the `Backdrop` component with a `Popper` for displaying code blocks, enhancing UI flexibility and context-aware presentation.
- Added a` Grow` transition to the Popper for both opening and closing, providing a smoother user experience.
- Implemented a reusable `useOutsideClick` hook for the Popper, enabling it to close when clicking outside, and potentially useful for future components.
- Finally remembered to update the title in `README`
<!--
Please do not leave this blank
This PR [adds/removes/fixes/replaces] the [feature/bug/etc].
-->

## What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [ ] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [x] 🎨 Style
- [x] 🧑‍💻 Code Refactor
- [ ] ✅ Test
- [ ] ⏩ Revert

<!-- note: PRs with deleted sections will be marked invalid -->

<!--
  For Work In Progress Pull Requests, please use the Draft PR feature,
  see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

  For a timely review/response, please avoid force-pushing additional
  commits if your PR already received reviews or comments.

  Before submitting a Pull Request, please ensure you've done the following:
  - 📖 Read the Open Sauced Contributing Guide: https://github.com/open-sauced/.github/blob/main/CONTRIBUTING.md.
  - 📖 Read the Open Sauced Code of Conduct: https://github.com/open-sauced/.github/blob/main/CODE_OF_CONDUCT.md.
  - 👷‍♀️ Create small PRs. In most cases, this will be possible.
  - ✅ Provide tests for your changes.
  - 📝 Use descriptive commit messages.
  - 📗 Update any related documentation and include any relevant screenshots.
-->
